### PR TITLE
feat: Add option to control player behaviour on video ID change

### DIFF
--- a/packages/component/src/index.ts
+++ b/packages/component/src/index.ts
@@ -1,6 +1,7 @@
 import { defineComponent, h, ref, toRefs } from 'vue';
 import { usePlayer } from '@vue-youtube/core';
 
+import type { OnVideoIdChange } from '@vue-youtube/core';
 import type { PlayerVars } from '@vue-youtube/shared';
 import type { PropType } from 'vue';
 
@@ -31,6 +32,10 @@ export const YoutubeIframe = defineComponent({
       type: Boolean as PropType<boolean>,
       default: true,
     },
+    onVideoIdChange: {
+      type: String as PropType<OnVideoIdChange>,
+      default: 'play',
+    },
   },
   emits: [
     'playback-quality-change',
@@ -55,6 +60,7 @@ export const YoutubeIframe = defineComponent({
       onError,
       onReady,
     } = usePlayer(videoId, target, {
+      onVideoIdChange: props.onVideoIdChange,
       playerVars: props.playerVars,
       height: props.height,
       cookie: props.cookie,

--- a/packages/core/src/manager/index.ts
+++ b/packages/core/src/manager/index.ts
@@ -23,6 +23,12 @@ export interface Manager {
   _state: ManagerState;
 }
 
+export const withDefaultManagerOptions = (options: Partial<ManagerOptions>): ManagerOptions => {
+  return {
+    deferLoading: options.deferLoading ?? { enabled: false, autoLoad: false },
+  };
+};
+
 export const injectManager = () => {
   const manager = inject<Manager>(PROVIDE_KEY);
 
@@ -39,13 +45,8 @@ export const injectManager = () => {
  * @see https://vue-youtube.github.io/docs/usage/manager
  * @returns Manager
  */
-export const createManager = (options?: ManagerOptions) => {
-  const managerOptions = options || {
-    deferLoading: {
-      enabled: false,
-      autoLoad: false,
-    },
-  };
+export const createManager = (options: Partial<ManagerOptions> = {}) => {
+  const managerOptions = withDefaultManagerOptions(options);
 
   const state: ManagerState = {
     backlog: new Map<string, RegisterFunction>(),

--- a/packages/core/src/manager/types.ts
+++ b/packages/core/src/manager/types.ts
@@ -8,7 +8,7 @@ export type RegisterFunctionReturn = { factory: any; id: string };
  * @see https://vue-youtube.github.io/docs/usage/manager#options
  */
 export interface ManagerOptions {
-  deferLoading?: DeferLoadingOption;
+  deferLoading: DeferLoadingOption;
 }
 
 /**

--- a/packages/core/src/options.ts
+++ b/packages/core/src/options.ts
@@ -1,5 +1,7 @@
 import type { PlayerVars } from '@vue-youtube/shared';
 
+export type OnVideoIdChange = 'play' | 'cue';
+
 /**
  * Possible options which can be provided via the `usePlayer` composable.
  *
@@ -33,10 +35,17 @@ export interface UsePlayerOptions {
    * When this option is `true` the host `https://www.youtube.com` is used, otherwise `https://www.youtube-nocookie.com`
    */
   cookie: boolean;
+
+  /**
+   * When this option is `play` the player will automatically start playing when the video ID changes, defaults to `play`.
+   * It is also possible to cue the video instead by setting this option to `cue`.
+   */
+  onVideoIdChange: OnVideoIdChange;
 }
 
-export const withConfigDefaults = (options: Partial<UsePlayerOptions>): UsePlayerOptions => {
+export const withDefaultPlayerOptions = (options: Partial<UsePlayerOptions>): UsePlayerOptions => {
   return {
+    onVideoIdChange: options.onVideoIdChange ?? 'play',
     playerVars: options.playerVars ?? {},
     cookie: options.cookie ?? true,
     height: options.height ?? 720,


### PR DESCRIPTION
Adresses #21.

This PR adds a new option to the `usePlayer` composable: `onVideoIdChange`. This option accepts either `play` (default) or `cue`. When the option is set to `play`, the player will immediately start playing the new video when the ID is changed. On the other hand, `cue` will only queue the new video.

Playback can be started by via player interaction of the user or by calling `instance.value?.playVideo()` or using the `togglePlay` helper.

## Example

```vue
<template>
  <div ref="yt" />
</template>

<script setup lang="ts">
import { usePlayer } from '@vue-youtube/core';
import { ref } from 'vue';

const videoId = ref('dQw4w9WgXcQ');
const yt = ref();

usePlayer(videoId, yt, {
  onVideoIdChange: 'cue',
  playerVars: {
    autoplay: 1,
    mute: 1,
  },
});

setTimeout(() => {
  videoId.value = 'h0ffIJ7ZO4U';
}, 5000);
</script>
```