### PR TITLE
fix: Expose missing helper functions in component

### DIFF
--- a/packages/component/src/index.ts
+++ b/packages/component/src/index.ts
@@ -53,6 +53,8 @@ export const YoutubeIframe = defineComponent({
       instance,
       togglePlay,
       toggleMute,
+      toggleLoop,
+      toggleShuffle,
       onPlaybackQualityChange,
       onPlaybackRateChange,
       onStateChange,
@@ -95,6 +97,8 @@ export const YoutubeIframe = defineComponent({
       instance,
       togglePlay,
       toggleMute,
+      toggleLoop,
+      toggleShuffle,
     });
 
     return () => {


### PR DESCRIPTION
Previously the component didn't forward two helper functions: `toggleLoop` and `toggleShuffle`. They are now exposed by the component.